### PR TITLE
add CI to push to pub.dev

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,13 @@
+name: publish
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  push:
+    tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
+
+jobs:
+  publish:
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+


### PR DESCRIPTION
* Adds CI to publish tagged releases to `pub.dev`
* Open to ideas on testing - no option to do a try run with the action I'm using afaiu.